### PR TITLE
some fixes for path separator on Windows

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -32,7 +32,7 @@ Utils =
     # Ensure that we're dealing with absolute paths across the board
     files = files.map (f) -> path.resolve resolveRoot, f
     # And that the strip prefixes all end with a /, to avoid a target path being absolute.
-    stripPrefixes = stripPrefixes.map (p) -> "#{path.resolve resolveRoot, p}/"
+    stripPrefixes = stripPrefixes.map (p) -> path.join( "#{path.resolve resolveRoot, p}/" )
 
     # Prefixes are stripped in order of most specific to least (# of directories deep)
     prefixes = stripPrefixes.sort (a,b) => @pathDepth(b) - @pathDepth(a)

--- a/lib/utils/style_helpers.coffee
+++ b/lib/utils/style_helpers.coffee
@@ -40,7 +40,7 @@ StyleHelpers =
     nodes    = []
     prevPath = []
     for file in files
-      targetChunks = file.targetPath.split '/'
+      targetChunks = file.targetPath.split path.join('/')
       pathChunks   = targetChunks[0...-1]
 
       # * If a file has the same name as a directory, it takes ownership of that directory's folder.
@@ -78,7 +78,7 @@ StyleHelpers =
       nodes.push
         type:   'file'
         data:    fileData
-        depth:   file.targetPath.split('/').length
+        depth:   file.targetPath.split( path.join('/') ).length
         outline: outlines[file.targetPath]
 
     @buildNodeTree nodes


### PR DESCRIPTION
using path.join('/') to get '/' on linux and '\' on Windows
