### PR TITLE
Update README to match reality, globs -> glob in .groc.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ groc, if you are interested.
 Groc supports a simple JSON configuration format once you know the config values that appeal to you.
 
 Create a `.groc.json` file in your project root, where each key maps to an option you would pass to
-the `groc` command.  File names and globs are defined as an array with the key `globs`.  For
+the `groc` command.  File names and globs are defined as an array with the key `glob`.  For
 example, groc's own configuration is:
 
     {
-      "globs": ["lib/**/*.coffee", "README.md", "lib/styles/*/style.sass", "lib/styles/*/*.jade"],
+      "glob": ["lib/**/*.coffee", "README.md", "lib/styles/*/style.sass", "lib/styles/*/*.jade"],
       "github": true
     }
 


### PR DESCRIPTION
The README currently says that "globs" is the key for files in the groc JSON, but the key is "glob". If you want to resolve this by changing the README then this pull request makes those minor changes. If you really do want it to accept "globs", or maybe accept both, consider this a bug report. :)

A related aside: Currently if you are using the JSON and the key is wrong or the list of globs is empty the `groc` command just prints a couple blank lines. Maybe a check for empty and a little warning could be a good idea.

Thanks for the great work. Cheers.
