### PR TITLE
Add support for puppet (.pp) files

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -65,6 +65,11 @@ LANGUAGES =
     pygmentsLexer:     'php'
     singleLineComment: ['//']
 
+  Puppet:
+    nameMatchers:      ['.pp']
+    pygmentsLexer:     'puppet'
+    singleLineComment: ['#']
+
   Python:
     nameMatchers:      ['.py']
     pygmentsLexer:     'python'


### PR DESCRIPTION
This adds support for puppet (.pp) file. I'm not sure if we want to merge it though, as it requires a lexer that is not part of pygments at the moment: https://github.com/rodjek/puppet-pygments-lexer. However, it is really easy to install, so why not?
