### PR TITLE
Add Rackup and Gemspec support.

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -81,7 +81,7 @@ LANGUAGES =
     singleLineComment: ['#']
 
   Ruby:
-    nameMatchers:      ['.rb']
+    nameMatchers:      ['.rb', '.ru', '.gemspec']
     pygmentsLexer:     'ruby'
     singleLineComment: ['#']
 


### PR DESCRIPTION
Here's a teeny little patch that treats Rackup and Gemspec files as Ruby code, which they are.
