### PR TITLE
use close event for pygmentize child process

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -144,7 +144,7 @@ Utils =
     pygmentize.stdout.addListener 'data', (data) =>
       result += data.toString()
 
-    pygmentize.addListener 'exit', (args...) =>
+    pygmentize.addListener 'close', (args...) =>
       # pygments spits it out wrapped in `<div class="highlight"><pre>...</pre></div>`.  We want to
       # manage the styling ourselves, so remove that.
       result = result.replace('<div class="highlight"><pre>', '').replace('</pre></div>', '')


### PR DESCRIPTION
this event is not called until all stdio pipes for the child have closed
and the process has exit, thereby ensuring all output from pygmentize is
captured
