### PR TITLE
Package File Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
 
   "engines": {
-    "node": ">= v0.4.12"
+    "node": ">= v0.5.0"
   },
   "dependencies": {
     "autorequire":   ">= 0.3.0",


### PR DESCRIPTION
`index.js` uses `require("json_file.json")` to load a JSON file,
but this is only supported in Node after version 5. The package
file is updated accordingly.

---

After trying to install groc on a node 0.4.12 install I found this inconsistency between the json file and the facilities used. My commit corrects the package file rather than making the package 0.4.12 compatible.
