### PR TITLE
Fix github URL

### DIFF
--- a/lib/utils/cli_helpers.coffee
+++ b/lib/utils/cli_helpers.coffee
@@ -81,6 +81,6 @@ CLIHelpers =
     return null unless match
 
     owner = match[1]
-    repo  = if match[1][-4..] == '.git' then match[1][0...-4] else match[1]
+    repo  = if match[2][-4..] == '.git' then match[2][0...-4] else match[2]
 
     "https://github.com/#{owner}/#{repo}"


### PR DESCRIPTION
Hello!

First off, I'd like to thank you for quickly pulling in my last changes and giving me the shout out for v0.8 compatibility!

I found a bug with the way github URLs are extracted from the repo information which caused the URL to always be #{username}/#{username}.  This pull request takes care of that problem.

On a slightly unrelated note, I was wondering if there is a setting to get the github link to show up during the local review process and not when publishing to github?  This would have been useful in tracking down this bug :)
