### PR TITLE
Use path.sep to fix compatibility with Windows

### DIFF
--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -39,7 +39,7 @@ class Project
     # We need to ensure that the project root is a strip prefix so that we properly generate
     # relative paths for our files.  Since strip prefixes are relative, it must be the first prefix,
     # so that they can strip from the remainder.
-    @stripPrefixes = ["#{@root}/"].concat @stripPrefixes
+    @stripPrefixes = [@root + path.sep].concat @stripPrefixes
 
     fileMap   = Utils.mapFiles @root, @files, @stripPrefixes
     indexPath = path.resolve @root, @index
@@ -60,7 +60,7 @@ class Project
         fileInfo =
           language:    language
           sourcePath:  currentFile
-          projectPath: currentFile.replace ///^#{@root + '/'}///, ''
+          projectPath: currentFile.replace ///^#{Utils.regexpEscape @root + path.sep}///, ''
           targetPath:  if currentFile == indexPath then 'index' else fileMap[currentFile]
 
         style.renderFile data, fileInfo, done

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -32,7 +32,7 @@ Utils =
     # Ensure that we're dealing with absolute paths across the board
     files = files.map (f) -> path.resolve resolveRoot, f
     # And that the strip prefixes all end with a /, to avoid a target path being absolute.
-    stripPrefixes = stripPrefixes.map (p) -> path.join( "#{path.resolve resolveRoot, p}/" )
+    stripPrefixes = stripPrefixes.map (p) -> path.join( "#{path.resolve resolveRoot, p}#{path.sep}" )
 
     # Prefixes are stripped in order of most specific to least (# of directories deep)
     prefixes = stripPrefixes.sort (a,b) => @pathDepth(b) - @pathDepth(a)
@@ -59,7 +59,7 @@ Utils =
       # Most globs look something like dir/**/*.ext, so strip up to the leading *
       arg = arg.replace /\*.*$/, ''
 
-      result.push arg if arg.slice(-1) == '/'
+      result.push arg if arg.slice(-1) == path.sep
 
     # For now, we try to avoid ambiguous situations by guessing the FIRST directory given.  The
     # assumption is that you don't want merged paths, but probably did specify the most important


### PR DESCRIPTION
This fix allows groc to work on Windows.
Previously it ran but would put absolute paths in the output, since groc was hard-coding the slash character as the path separator, but on Windows it is a backslash.
