### PR TITLE
added path seperator as a cli var for cases where path.sep is undefined

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -77,6 +77,12 @@ CLI = (inputArgs, callback) ->
       default:  '.'
       type:     'path'
 
+    pathsep:
+      describe: 'Path seperator, if not set defaults to path.sep (or / if path.sep is undefined)'
+      alias:    'ps'
+      default:  path.sep
+      type:     'string'
+
     style:
       describe: "The style to use when generating documentation."
       alias:    's'
@@ -127,6 +133,8 @@ CLI = (inputArgs, callback) ->
   argv = utils.CLIHelpers.extractArgv opts, optionsConfig
   # If we're in tracing mode, the parsed options are extremely helpful.
   utils.Logger.trace 'argv: %j', argv if argv['very-verbose']
+
+  path.sep = argv.pathsep ?= path.sep ?= '/'
 
   # Version checks short circuit before our pretty printing begins, since it is
   # one of those things that you might want to reference from other scripts.


### PR DESCRIPTION
Added 'pathsep' as a CLI var (or .groc.json config var), figured it might be worth sharing.   If the pathsep var is not provided and path.sep is undefined, path.sep is set to '/'.

I'm not terribly familiar with coffeescript, so please double-check me if you can :)

I had to make this change as we're running node v0.6.20, so path.sep was undefined.  I couldn't get groc to generate relative paths no matter what i tried config-wise.  A little bit of console logging exposed a whole bunch of 'undefined' getting injected into stripPaths because of the reliance on path.sep (which isn't introduced until node v0.8, I think).
