### PR TITLE
Push to the correct "gh-pages" remote

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -188,8 +188,10 @@ CLI = (inputArgs, callback) ->
 
   # ## GitHub
   else
-    publish_to_github = (error, url) ->
-      console.log "publish_to_github", error, url
+    # We want to be able to annotate generated documentation with the project's GitHub URL.  This is
+    # handy for things like generating links directly to each file's source.
+    utils.CLIHelpers.guessPrimaryGitHubURL argv['repository-url'], (error, url, remote) ->
+      console.log "publish_to_github", error, url, remote
 
       if error
         project.log.error error.message
@@ -218,7 +220,7 @@ CLI = (inputArgs, callback) ->
         # 2. Copies the generated docs from `.git/groc-tmp` over any existing files in the branch.
         # 3. Creates a commit with _just_ the generated docs; any additional files are removed.
         # 4. Cleans up and switches back to the user's original branch.
-        script = childProcess.spawn path.resolve(__dirname, '..', 'scripts', 'publish-git-pages.sh')
+        script = childProcess.spawn path.resolve(__dirname, '..', 'scripts', 'publish-git-pages.sh'), [remote]
 
         script.stdout.on 'data', (data) -> project.log.info  data.toString().trim()
         script.stderr.on 'data', (data) -> project.log.error data.toString().trim()
@@ -227,10 +229,3 @@ CLI = (inputArgs, callback) ->
           return callback new Error 'Git publish failed' if code != 0
 
           callback()
-
-    # We want to be able to annotate generated documentation with the project's GitHub URL.  This is
-    # handy for things like generating links directly to each file's source.
-    if argv['repository-url']?
-      publish_to_github null, argv['repository-url']
-    else
-      utils.CLIHelpers.guessPrimaryGitHubURL publish_to_github

--- a/lib/utils/cli_helpers.coffee
+++ b/lib/utils/cli_helpers.coffee
@@ -9,7 +9,7 @@ CLIHelpers =
     for optName, optConfig of config
       # * We support two tiers of default values.  First, we set up the hard-coded defaults specified
       #   as part of `config`.
-      # 
+      #
       # Also, `default` is a reserved name, hence `defaultVal`.
       defaultVal = extraDefaults?[optName] or optConfig.default
 
@@ -42,7 +42,7 @@ CLIHelpers =
 
   # ## guessPrimaryGitHubURL
 
-  guessPrimaryGitHubURL: (callback) ->
+  guessPrimaryGitHubURL: (repository_url, callback) ->
     # `git config --list` provides information about branches and remotes - everything we need to
     # attempt to guess the project's GitHub repository.
     #
@@ -58,22 +58,25 @@ CLIHelpers =
 
       # * If the user has a tracked `gh-pages` branch, chances are extremely high that its tracked
       #   remote is the correct github project.
-      pagesRemote = config['branch.gh-pages.remote']
-      if pagesRemote and config["remote.#{pagesRemote}.url"]
-        url = @extractGitHubURL config["remote.#{pagesRemote}.url"]
-        return callback null, url if url
+      pagesRemote = config['branch.gh-pages.remote'] ? "origin"
+      if repository_url?
+        return callback null, repository_url, pagesRemote
+      else
+        if config["remote.#{pagesRemote}.url"]
+          url = @extractGitHubURL config["remote.#{pagesRemote}.url"]
+          return callback null, url, pagesRemote if url
 
-      # * If that fails, we fall back to the origin remote if it is a GitHub repository.
-      url = @extractGitHubURL config['remote.origin.url']
-      return callback null, url if url
+        # * If that fails, we fall back to the origin remote if it is a GitHub repository.
+        url = @extractGitHubURL config['remote.origin.url']
+        return callback null, url, pagesRemote if url
 
-      # * We fall back to searching all remotes for a GitHub repository, and choose the first one
-      #   we encounter.
-      for key, value of config
-        url = @extractGitHubURL value
-        return callback null, url if url
+        # * We fall back to searching all remotes for a GitHub repository, and choose the first one
+        #   we encounter.
+        for key, value of config
+          url = @extractGitHubURL value
+          return callback null, url, pagesRemote if url
 
-      callback new Error "Could not guess a GitHub URL for the current repository :("
+        callback new Error "Could not guess a GitHub URL for the current repository :("
 
   # A quick helper that extracts a GitHub project URL from its repository URL.
   extractGitHubURL: (url) ->

--- a/scripts/publish-git-pages.sh
+++ b/scripts/publish-git-pages.sh
@@ -3,7 +3,7 @@ set -e # Stop on the first failure that occurs
 
 DOCS_PATH=.git/groc-tmp
 TARGET_BRANCH=gh-pages
-TARGET_REMOTE=origin
+[[ $1 ]] && TARGET_REMOTE=$1 || TARGET_REMOTE=origin
 
 # Git spits out status information on $stderr, and we don't want to relay that as an error to the
 # user.  So we wrap git and do error handling ourselves...
@@ -48,7 +48,7 @@ if [[ -e .gitignore ]]; then
 fi
 
 if [[ `git branch --no-color | grep " $TARGET_BRANCH"` == "" ]]; then
-  # Do a fetch from origin to see if it was created remotely
+  # Do a fetch from the target remote to see if it was created remotely
   exec_git fetch $TARGET_REMOTE
 
   # Does it exist remotely?
@@ -65,7 +65,8 @@ if [[ `git branch --no-color | grep " $TARGET_BRANCH"` == "" ]]; then
 
     exec_git clean -fdq
   else
-    echo "No local branch '$TARGET_BRANCH', checking out 'origin/$TARGET_BRANCH' and tracking that"
+    TARGET_REMOTE=origin
+    echo "No local branch '$TARGET_BRANCH', checking out '$TARGET_REMOTE/$TARGET_BRANCH' and tracking that"
     exec_git checkout -b $TARGET_BRANCH $TARGET_REMOTE/$TARGET_BRANCH
   fi
 
@@ -85,7 +86,7 @@ fi
 if [[ `git status -s` != "" ]]; then
   exec_git add -A
   exec_git commit -m "Generated documentation for $CURRENT_COMMIT"
-  exec_git push origin $TARGET_BRANCH
+  exec_git push $TARGET_REMOTE $TARGET_BRANCH
 fi
 
 # Clean up after ourselves


### PR DESCRIPTION
The current behavior is to push to "origin" regardless of the actual remote that is configured for the "gh-pages" branch. This change will use the configured remote name, defaulting to "origin" if all else fails.

For example, consider the following:

```
$ git config --get branch.gh-pages.remote
upstream
```

Currently running `groc --github` would result in the documentation being pushed to `origin`. With this change the documentation will be pushed to the `upstream` remote.
