### PR TITLE
Allow unbuffered jade comments

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -43,7 +43,7 @@ LANGUAGES =
   Jade:
     nameMatchers:      ['.jade']
     pygmentsLexer:     'jade'
-    singleLineComment: ['//']
+    singleLineComment: ['//', '//-']
 
   Java:
     nameMatchers:      ['.java']


### PR DESCRIPTION
I would like to document my jade files, but I don't want to add the comments to the rendered html files. Therefor, in Jade, it is possible to use unbuffered comments (https://github.com/visionmedia/jade#a6-4), which will not show up in the rendered html file(s).
