### PR TITLE
Should the nav behavior really work this way?

### DIFF
--- a/lib/styles/default/behavior.coffee
+++ b/lib/styles/default/behavior.coffee
@@ -228,6 +228,13 @@ buildTOCNode = (node, metaInfo) ->
 
   discloser$ = $('<span class="discloser"/>').prependTo label$
   discloser$.addClass 'placeholder' unless node.children?.length > 0
+
+  # CONVERSATION STARTER:
+  # Should the arrow icon on click be what makes the nav tree expand?
+  # I feel like the entire li should make the nav tree expand. The style
+  # changes when you click the li... but when the list doesn't expand
+  # when the style changes... that just feels broken.
+  # What do you think?
   discloser$.click (evt) ->
     node$.toggleClass 'expanded'
     evt.preventDefault()


### PR DESCRIPTION
Hey there, Let me start by saying that I think this project is awesome. 

This pull request is not a solution... it is just a conversation starter. I was poking around on the site and noticed that the behavior of expanding the nav is reliant on the user clicking the arrow icon. I didn't discover this right off the bat. I clicked the <li> a number of times and saw that it added the class of "selected"... but this was confusing as the content in the view didn't change.... just the background style highlighted. So it got me thinking... maybe I should click the arrow icon. And then it expanded the list. This seems broken to me. I feel like all items in the list should have some behavior that will have some actionable change in the view. For example... if there is no item in the list.. then change the main content view. If there is a base page, or default view associated with the list item with an arrow icon, it should change the content in the main view and also expand the list... if there is no default content for the list item with the arrow icon... then it should at least "expand" the list to show the sub nav contents, no?

I humbly send this pull request to ask if any thought has gone into this and if there is a reason that the behavior of the nav doesn't work this way already. I would have sketched out an implementation of the working code if I could fully "groc" all the code involved in this... but then I figured I would get this comment out instead as I am sure that there are folks who know this codebase way better than I do and they would have opinions on how this should really work and also how you guys want to do things here.

Thanks... if you want to connect to talk about this further.. please ping me. 

:bike: :bike: :bike: :+1: 
