### PR TITLE
Block comments and configurable 'ignore this comment' flag

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -9,123 +9,149 @@ module.exports = LANGUAGES =
     nameMatchers:      ['.c', '.h']
     pygmentsLexer:     'c'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   CSharp:
     nameMatchers:      ['.cs']
     pygmentsLexer:     'csharp'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   'C++':
     nameMatchers:      ['.cpp', '.hpp', '.c++', '.h++', '.cc', '.hh', '.cxx', '.hxx']
     pygmentsLexer:     'cpp'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   Clojure:
     nameMatchers:      ['.clj']
     pygmentsLexer:     'clojure'
     singleLineComment: [';;']
+    ignorePrefix:      '}'
 
   CoffeeScript:
     nameMatchers:      ['.coffee', 'Cakefile']
     pygmentsLexer:     'coffee-script'
     singleLineComment: ['#']
+    ignorePrefix:      '}'
 
   Go:
     nameMatchers:      ['.go']
     pygmentsLexer:     'go'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   Haskell:
     nameMatchers:      ['.hs']
     pygmentsLexer:     'haskell'
     singleLineComment: ['--']
+    ignorePrefix:      '}'
 
   Jade:
     nameMatchers:      ['.jade']
     pygmentsLexer:     'jade'
     singleLineComment: ['//', '//-']
+    ignorePrefix:      '}'
 
   Java:
     nameMatchers:      ['.java']
     pygmentsLexer:     'java'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   JavaScript:
     nameMatchers:      ['.js']
     pygmentsLexer:     'javascript'
     singleLineComment: ['//']
+    multiLineComment:  ['/*', '*', '*/']
+    ignorePrefix:      '}'
 
   Jake:
     nameMatchers:      ['.jake']
     pygmentsLexer:     'javascript'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   LaTeX:
     nameMatchers:      ['.tex', '.latex', '.sty']
     pygmentsLexer:     'latex'
     singleLineComment: ['%']
+    ignorePrefix:      '}'
 
   Lua:
     nameMatchers:      ['.lua']
     pygmentsLexer:     'lua'
     singleLineComment: ['--']
+    ignorePrefix:      '}'
 
   Make:
     nameMatchers:      ['Makefile']
     pygmentsLexer:     'make'
     singleLineComment: ['#']
+    ignorePrefix:      '}'
 
   'Objective-C':
     nameMatchers:      ['.m', '.mm']
     pygmentsLexer:     'objc'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   Perl:
     nameMatchers:      ['.pl', '.pm']
     pygmentsLexer:     'perl'
     singleLineComment: ['#']
+    ignorePrefix:      '}'
 
   PHP:
     nameMatchers:      [/\.php\d?$/, '.fbp']
     pygmentsLexer:     'php'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   Puppet:
     nameMatchers:      ['.pp']
     pygmentsLexer:     'puppet'
     singleLineComment: ['#']
+    ignorePrefix:      '}'
 
   Python:
     nameMatchers:      ['.py']
     pygmentsLexer:     'python'
     singleLineComment: ['#']
+    ignorePrefix:      '}'
 
   Ruby:
     nameMatchers:      ['.rb', '.ru', '.gemspec']
     pygmentsLexer:     'ruby'
     singleLineComment: ['#']
+    ignorePrefix:      '}'
 
   Sass:
     nameMatchers:      ['.sass']
     pygmentsLexer:     'sass'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   SCSS:
     nameMatchers:      ['.scss']
     pygmentsLexer:     'scss'
     singleLineComment: ['//']
+    ignorePrefix:      '}'
 
   Shell:
     nameMatchers:      ['.sh']
     pygmentsLexer:     'sh'
     singleLineComment: ['#']
+    ignorePrefix:      '}'
 
   SQL:
     nameMatchers:      ['.sql']
     pygmentsLexer:     'sql'
     singleLineComment: ['--']
+    ignorePrefix:      '}'
 
   YAML:
     nameMatchers:      ['.yml', '.yaml']
     pygmentsLexer:     'yaml'
     singleLineComment: ['#']
+    ignorePrefix:      '}'


### PR DESCRIPTION
This commit adds the ability to define a block comment syntax
for individual languages (currently, only javascript -- I'm lazy)
Similar to singleLineComment, multiLineComment is an array, however,
unlike singleLineComment, it is not an array of alternatives; order
matters.  multiLineComment[0] opens a block comment, [2] closes it
and [1] is an optional beginning of line marker, ex:

/*
- This is a block comment
  */

/\* is the opener, */ is the closer, and \* is a line marker

A line marker can also succeed or preceed an opener/closer, e.g.:

/**
- Foo
  **/

Additionally, you can use block syntax on a single line:

/\* This is a single line comment */

This opens up the possibility of adding additional languages
that only have block comments, like HTML or Handlebars

EDIT: Additionally, this commit makes the 'ignore this comment' flag configurable, since the default ( '}' ) wouldn't be very friendly in Handlebars or Mustache, where '}' is part of the language
