### PR TITLE
Enable 'github' and 'table' Showdown Extensions

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -213,7 +213,7 @@ module.exports = Utils =
   # Annotate an array of segments by running their comments through
   # [showdown](https://github.com/coreyti/showdown).
   markdownComments: (segments, project, callback) ->
-    converter = new showdown.converter()
+    converter = new showdown.converter(extensions: ['github', 'table'])
 
     try
       for segment, segmentIndex in segments


### PR DESCRIPTION
It might be even better to expose an 'extensions' configuration option, but I didn't have time to do that.
