### PR TITLE
Initial Support for Doc Tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
-require('coffee-script')
+require('coffee-script');
 
 module.exports = {
   PACKAGE_INFO: require('./lib/package_info'),
   CLI:          require('./lib/cli'),
   LANGUAGES:    require('./lib/languages'),
+  DOC_TAGS:     require('./lib/doc_tags'),
   Project:      require('./lib/project'),
-  styles:       require('./lib/styles'),
-}
+  styles:       require('./lib/styles')
+};

--- a/lib/doc_tags.coffee
+++ b/lib/doc_tags.coffee
@@ -1,0 +1,183 @@
+# # Known Doc Tags
+
+humanize = require './utils/humanize'
+
+# This is a sample doc tagged block comment
+#
+# @public
+# @module DOC_TAGS
+# @type   {Object}
+module.exports = DOC_TAGS =
+  description:
+    section:     'description'
+    markdown:    '{value}'
+
+  internal:
+    section:     'access'
+  'private':
+    section:     'access'
+  'protected':
+    section:     'access'
+  'public':
+    valuePrefix: 'as'
+    section:     'access'
+  'static':
+    section:     'access'
+
+  constructor:
+    section:     'special'
+  destructor:
+    section:     'special'
+
+  constant:
+    section:     'type'
+  method:
+    section:     'type'
+  module:
+    section:     'type'
+  'package':
+    section:     'type'
+  property:
+    section:     'type'
+
+  accessor:
+    section:     'flag'
+    markdown:    'is an accessor'
+  async:
+    section:     'flag'
+    markdown:    'is asynchronous'
+  asynchronous:  'async'
+  getter:
+    section:     'flag'
+    markdown:    'is a getter'
+  recursive:
+    section:     'flag'
+    markdown:    'is recursive'
+  refactor:
+    section:     'flag'
+    markdown:    'needs to be refactored'
+  setter:
+    section:     'flag'
+    markdown:    'is a setter'
+
+  alias:
+    valuePrefix: 'as'
+    section:     'metadata'
+    markdown:    'is aliased as {value}'
+  publishes:
+    section:     'metadata'
+  requests:
+    section:     'metadata'
+    markdown:    'makes an ajax request to {value}'
+  subscribes:
+    valuePrefix: 'to'
+    section:     'metadata'
+    markdown:    'subscribes to {value}'
+  type:
+    section:     'metadata'
+    markdown:    'of type _{value}_'
+
+  todo:
+    section:     'todo'
+    markdown:    'TODO: {value}'
+
+  example:
+    section:     'example'
+  examples:      'example'
+  usage:         'example'
+
+  howto:
+    section:     'howto'
+
+  note:
+    section:     'discard'
+  notes:         'note'
+
+  param:
+    section:     'params'
+    # parses function parameters
+    #
+    # @public
+    # @method parseValue
+    #
+    # @param  {String} value Text that follows @param
+    #
+    # @return {Object}
+    parseValue:  (value) ->
+      parts = value.match /^\{([^\}]+)\}\s+(\[?)([\w\.\$]+)(?:=([^\s\]]+))?(\]?)\s*(.*)$/
+      types:        (parts[1]?.split /\|{1,2}/g)
+      isOptional:   (parts[2] == '[' and parts[5] == ']')
+      varName:      parts[3]
+      isSubParam:   /\./.test parts[3]
+      defaultValue: parts[4]
+      description:  parts[6]
+
+    # converts parsed values to markdown text
+    #
+    # @public
+    # @method markdown
+    #
+    # @param  {Object}   value
+    # @param  {String[]} value.types
+    # @param  {Boolean}  value.isOptional=false
+    # @param  {String}   value.varName
+    # @param  {Boolean}  value.isSubParam=false
+    # @param  {String}   [value.defaultValue]
+    # @param  {String}   [value.description]
+    #
+    # @return {String} should be in markdown syntax
+    markdown:    (value) ->
+      types = (
+        for type in value.types
+          if type.match /\[\]$/
+            "an Array of #{humanize.pluralize type.replace(/\[\]$/, "")}"
+          else
+            "#{humanize.article type} #{type}"
+      )
+
+      fragments = []
+
+      fragments.push 'is optional' if value.isOptional
+      verb = 'must'
+
+      if types.length > 1
+        verb = 'can'
+      else if types[0] == 'a Mixed'
+        verb = 'can'
+        types[0] = 'of any type'
+      else if types[0] == 'an Array of Mixeds'
+        verb = 'can'
+        types[0] = 'an Array of any type'
+
+      fragments.push "#{verb} be #{humanize.joinSentence types, 'or'}"
+      fragments.push "has a default value of #{value.defaultValue}" if value.defaultValue?
+
+      "#{if value.isSubParam then "    *" else "*"} **#{value.varName} #{humanize.joinSentence fragments}.**#{if value.description.length then '<br/>(' else ''}#{value.description}#{if value.description.length then ')' else ''}"
+  params:        'param'
+  parameters:    'param'
+
+  'return':
+    section:     'returns'
+    parseValue:  (value) ->
+      parts = value.match /^\{([^\}]+)\}\s*(.*)$/
+      types:       parts[1].split /\|{1,2}/g
+      description: parts[2]
+    markdown:     (value) ->
+      types = ("#{humanize.article type} #{type}" for type in value.types)
+      "**returns #{types.join ' or '}**#{if value.description.length then '<br/>(' else ''}#{value.description}#{if value.description.length then ')' else ''}"
+  returns:       'return'
+  throw:
+    section:     'returns'
+    parseValue:  (value) ->
+      parts = value.match /^\{([^\}]+)\}\s*(.*)$/
+      types:       parts[1].split /\|{1,2}/g
+      description: parts[2]
+    markdown:    (value) ->
+      types = ("#{humanize.article type} #{type}" for type in value.types)
+      "**can throw #{types.join ' or '}**#{if value.description.length then '<br/>(' else ''}#{value.description}#{if value.description.length then ')' else ''}"
+  throws:        'throw'
+
+  defaultNoValue:
+    section:     'flag'
+  defaultHasValue:
+    section:     'metadata'

--- a/lib/styles/default.coffee
+++ b/lib/styles/default.coffee
@@ -6,7 +6,7 @@ coffeeScript = require 'coffee-script'
 fsTools      = require 'fs-tools'
 jade         = require 'jade'
 uglifyJs     = require 'uglify-js'
-
+humanize     = require '../utils/humanize'
 Base = require './base'
 
 
@@ -112,3 +112,51 @@ module.exports = class Default extends Base
         @log.trace 'Wrote %s', outputPath
 
         callback()
+
+  renderDocTags: (segments) ->
+    for segment, segmentIndex in segments when segment.tagSections?
+
+      sections = segment.tagSections
+      output = ''
+      metaOutput = ''
+      accessClasses = 'doc-section'
+
+      accessClasses += " doc-section-#{tag.name}" for tag in sections.access if sections.access?
+
+      segment.accessClasses = accessClasses
+
+      firstPart = []
+      firstPart.push tag.markdown for tag in sections.access if sections.access?
+      firstPart.push tag.markdown for tag in sections.special if sections.special?
+      firstPart.push tag.markdown for tag in sections.type if sections.type?
+
+      metaOutput += "#{humanize.capitalize firstPart.join(' ')}"
+      if sections.flags? or sections.metadata?
+        secondPart = []
+        firstPart.push tag.markdown for tag in sections.flags if sections.flags?
+        firstPart.push tag.markdown for tag in sections.metadata if sections.metadata?
+        metaOutput += " #{humanize.joinSentence secondPart}"
+
+      output += "<span class='doc-section-header'>#{metaOutput}</span>\n\n" if metaOutput?
+
+      output += "#{tag.markdown}\n\n" for tag in sections.description if sections.description?
+
+      output += "#{tag.markdown}\n\n" for tag in sections.todo if sections.todo?
+
+      if sections.params?
+        output += 'Parameters:\n\n'
+        output += "#{tag.markdown}\n\n" for tag in sections.params
+
+      if sections.returns?
+        output += (humanize.capitalize(tag.markdown) for tag in sections.returns if sections.returns?).join('<br/>**and** ')
+
+      if sections.howto?
+        output += "\n\n#{humanize.gutterify tag.markdown, 0}" for tag in sections.howto
+
+      if sections.example?
+        output += "\n\n#{humanize.gutterify tag.markdown, 4}" for tag in sections.example
+
+      # TODO: make this generic:
+      #output = output.replace(/([A-Z]+-\d+)/g, '<a href="https://jira.gilt.com/browse/$1">$1</a>')
+
+      segment.comments = output.split '\n'

--- a/lib/styles/default/docPage.jade
+++ b/lib/styles/default/docPage.jade
@@ -23,7 +23,7 @@ html(lang="en")
       - for (var i in segments)
         .segment
           - if (segments[i].markdownedComments != '')
-            .comments
+            div(class="comments " + (segments[i].accessClasses || ''))
               .wrapper!= segments[i].markdownedComments
 
           - if (segments[i].highlightedCode != '')

--- a/lib/utils/humanize.coffee
+++ b/lib/utils/humanize.coffee
@@ -1,0 +1,35 @@
+module.exports = humanize =
+  joinSentence: (parts, conjunctive='and') ->
+    if parts.length > 2
+      [parts[0..-2].join(', '), parts[parts.length - 1]].join(", #{conjunctive} ")
+    else
+      parts.join(" #{conjunctive} ")
+
+  capitalize: (sentence) ->
+    if sentence.length
+      console.log(sentence)
+      parts = sentence.match /^(\s*)([_\*`]*)(\s*)(\w)(.*)$/
+      "#{parts[1]}#{parts[2]}#{parts[3]}#{parts[4].toUpperCase()}#{parts[5]}"
+    else
+      ''
+
+  article: (word) ->
+    if word[0].toLowerCase() in ['a', 'e', 'i', 'o', 'u']
+      'an'
+    else
+      'a'
+
+  pluralizationRules: [
+    { regex: /([bcdfghjklmnpqrstvwxz])y$/, replacement: '$1ies' },
+    { regex: /(ch|sh|x|ss|s)$/, replacement: '$1es' },
+    { regex: /$/, replacement: 's' }
+  ]
+
+  pluralize: (word) ->
+    return word.replace(rule.regex, rule.replacement) for rule in humanize.pluralizationRules when rule.regex.test word
+
+  gutterify: (text, gutterWidth) ->
+    extantMinimumGutterWidth = text.match(/^ +/gm).sort()[0].length
+    gutter = '            '[0..gutterWidth].slice(1)
+    regex = ///^ {#{extantMinimumGutterWidth}}///gm
+    text.replace regex, gutter


### PR DESCRIPTION
This commit adds support for JavaDoc/JSDoc style documentation tags
e.g. @public, or @requests /foo, or @param {Type} [foo=bar] Foo!

closes #28
