### PR TITLE
Fix: Multiline-descriptions for “@param”, “@return(s)” and “@throws” jsdoc-tags do not work

### DIFF
--- a/lib/doc_tags.coffee
+++ b/lib/doc_tags.coffee
@@ -2,6 +2,9 @@
 
 humanize = require './utils/humanize'
 
+collapse_space = (value) ->
+  value.replace /\s+/g, ' '
+
 # This is a sample doc tagged block comment
 #
 # @public
@@ -107,7 +110,7 @@ module.exports = DOC_TAGS =
     #
     # @return {Object}
     parseValue:  (value) ->
-      parts = value.match /^\{([^\}]+)\}\s+(\[?)([\w\.\$]+)(?:=([^\s\]]+))?(\]?)\s*(.*)$/
+      parts = collapse_space(value).match /^\{([^\}]+)\}\s+(\[?)([\w\.\$]+)(?:=([^\s\]]+))?(\]?)\s*(.*)$/
       types:        (parts[1]?.split /\|{1,2}/g)
       isOptional:   (parts[2] == '[' and parts[5] == ']')
       varName:      parts[3]
@@ -167,7 +170,7 @@ module.exports = DOC_TAGS =
   'return':
     section:     'returns'
     parseValue:  (value) ->
-      parts = value.match /^\{([^\}]+)\}\s*(.*)$/
+      parts = collapse_space(value).match /^\{([^\}]+)\}\s*(.*)$/
       types:       parts[1].split /\|{1,2}/g
       description: parts[2]
     markdown:     (value) ->
@@ -177,7 +180,7 @@ module.exports = DOC_TAGS =
   throw:
     section:     'returns'
     parseValue:  (value) ->
-      parts = value.match /^\{([^\}]+)\}\s*(.*)$/
+      parts = collapse_space(value).match /^\{([^\}]+)\}\s*(.*)$/
       types:       parts[1].split /\|{1,2}/g
       description: parts[2]
     markdown:    (value) ->


### PR DESCRIPTION
Hi everybody,

first of all - thanks for your hard work so far :+1: 

The regular-expresions for “@param”, “@return(s)” and “@throws” jsdoc-tags in `lib/doc_tags.coffee` have been bound to a single line description:

```
parts = value.match /^…$/
```

Therefore multiline-descriptions break the process and throw an exception, as multiline-input does not match and returns **null**.

An example I stumbled upon (the method's `template`-parameter description):

```
##
# HTML template processor. … (shortened a bit)
# 
# @param  {Context} context  Context created from the input data object.
# @param  {Element} template DOM node of the template. This will be processed
#                            in place. After processing, it will still be a
#                            valid template that, if processed again with the
#                            same data, it will remain unchanged.
# @param  {Object}  options  Options passed to `Processor.create()`.
# @return {void}
process: (context, template, options) ->
  …
```

My solution to make this work is trivial:

```
parts = value.replace(/\s+/g, ' ').match /^…$/
```

In my setup it does not break anything and there seems to be no objection to go this way.

What do you think ? I'd like to use multiline-descriptions and would be glad if you pull my (a little bit polished) solution or give me a hint, what alternatives I might have missed.

(Hint: This is the second pull-request for this issue, as I messed up the original request …)
