### PR TITLE
Fix: process block-comments before single-line-comments

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -136,6 +136,16 @@ module.exports = Utils =
         else if (match = line.match blockLineMatcher)?
           currSegment.comments.push match[2]
 
+      # Match that line to the language's multi line comment syntax, if it exists
+      else if language.multiLineComment? and (match = line.match blockStartMatcher)?
+
+        if currSegment.code.length > 0
+          segments.push currSegment
+          currSegment = new @Segment
+
+        currSegment.comments.push match[2]
+        inBlock = true
+
       # Match that line to the language's single line comment syntax.
       #
       # However, we treat all comments beginning with } as inline code commentary.
@@ -156,16 +166,6 @@ module.exports = Utils =
 
         else
           currSegment.code.push line
-
-      # Match that line to the language's multi line comment syntax, if it exists
-      else if language.multiLineComment? and (match = line.match blockStartMatcher)?
-
-        if currSegment.code.length > 0
-          segments.push currSegment
-          currSegment = new @Segment
-
-        currSegment.comments.push match[2]
-        inBlock = true
 
       else
         currSegment.code.push line


### PR DESCRIPTION
I'd like to process CoffeeScript block-comments. The current implementation makes it really difficult to distinguish between CoffeeScript's single-line comments starting with `#` and multi-line block-comments starting with `###`, because single-line comments (initially) match multi-line comments in the context of CoffeeScripts. Therefore we can not enter the block-comment state during the process.

This commit simply swaps the processing order without touching anything else. As far as I can say this doesn't harm the process in any way.

I'd glad if you could pull this change in and I promise to offer the missing part as soon as I finished it. The reason why I'd like to split this change into two parts are the outstanding pull-requests which might (no, they certainly will) lead to conflicts depending on your decisions to merging them in or not and the order you do it.

Thanks,
Stephan
