### PR TITLE
Fix: A typo prevents flag- and metadata-doctags to appear

### DIFF
--- a/lib/styles/default.coffee
+++ b/lib/styles/default.coffee
@@ -133,8 +133,8 @@ module.exports = class Default extends Base
       metaOutput += "#{humanize.capitalize firstPart.join(' ')}"
       if sections.flags? or sections.metadata?
         secondPart = []
-        firstPart.push tag.markdown for tag in sections.flags if sections.flags?
-        firstPart.push tag.markdown for tag in sections.metadata if sections.metadata?
+        secondPart.push tag.markdown for tag in sections.flags if sections.flags?
+        secondPart.push tag.markdown for tag in sections.metadata if sections.metadata?
         metaOutput += " #{humanize.joinSentence secondPart}"
 
       output += "<span class='doc-section-header'>#{metaOutput}</span>\n\n" if metaOutput?


### PR DESCRIPTION
There seems to be (cut'n'paste) typo in `lib/styles/default.coffee`. I'm quite sure you wanted to use `secondPart` where it currently reads `firstPart` - look into the tiny patch … please.

Thanks for pulling …
Stephan
