### PR TITLE
Fix: faulty detection of email-adresses as doctags

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -284,7 +284,7 @@ module.exports = Utils =
     pygmentize.stdin.end()
 
   parseDocTags: (segments, project, callback) ->
-    TAG_REGEX = /(^|\s)@(\w+)(?:\s+(.*))?/
+    TAG_REGEX = /(?:^|\s)@(\w+)(?:\s+(.*))?/
     TAG_VALUE_REGEX = /^(?:"(.*)"|'(.*)'|\{(.*)\}|(.*))$/
 
     try
@@ -300,8 +300,8 @@ module.exports = Utils =
         for line in segment.comments when line?
           if (match = line.match TAG_REGEX)?
             currTag = {
-              name: match[2]
-              value: match[3] || ''
+              name: match[1]
+              value: match[2] || ''
             }
             tags.push currTag
           else

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -284,7 +284,7 @@ module.exports = Utils =
     pygmentize.stdin.end()
 
   parseDocTags: (segments, project, callback) ->
-    TAG_REGEX = /@(\w+)(?:\s+(.*))?/
+    TAG_REGEX = /(^|\s)@(\w+)(?:\s+(.*))?/
     TAG_VALUE_REGEX = /^(?:"(.*)"|'(.*)'|\{(.*)\}|(.*))$/
 
     try
@@ -300,8 +300,8 @@ module.exports = Utils =
         for line in segment.comments when line?
           if (match = line.match TAG_REGEX)?
             currTag = {
-              name: match[1]
-              value: match[2] || ''
+              name: match[2]
+              value: match[3] || ''
             }
             tags.push currTag
           else


### PR DESCRIPTION
In preparation of multi-line block-comments support for CoffeScripts I discovered that sometimes email-adresses are treated as _@doctags_, because the related regular-expression `TAG_REGEX = /@(\w+)(?:\s+(.*))?/` in _lib/utils.coffee_ simply matches the _@domain.tld_-part of email-adresses.

My (dumb) solution to this problem modifies the regular-expression (and it's match-result usage), so it cares about the @-preceding character:

```
# @ preceded by the start of line or a space-character and followed by word characters …
TAG_REGEX = /(^|\s)@(\w+)(?:\s+(.*))?/
```

Hence I make the assumption, that _@doctags_ are always preceded by space or placed at the beginning of line. 

Alternatively we could assume that _@doctags_ never contain a dot and modify the regular expression accordingly:

```
# @ followed by at least one word character, which in turn is not followed by a dot plus word-characters.
TAG_REGEX = /@(\w++(?!\.\w))(?:\s+(.*))?/  
```

The latter solution is untested and just a source of inspiration. I'd prefer the first one (= this patch) and appreciate any feedback.

Cheers,
Stephan
