### PR TITLE
Feature: simplify PACKAGE_INFO implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 require('coffee-script');
 
 module.exports = {
-  PACKAGE_INFO: require('./lib/package_info'),
+  PACKAGE_INFO: require('./package.json'),
   CLI:          require('./lib/cli'),
   LANGUAGES:    require('./lib/languages'),
   DOC_TAGS:     require('./lib/doc_tags'),

--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -9,7 +9,7 @@ optimist = require 'optimist'
 
 CLIHelpers   = require './utils/cli_helpers'
 Logger       = require './utils/logger'
-PACKAGE_INFO = require './package_info'
+PACKAGE_INFO = require '../package.json'
 Project      = require './project'
 styles       = require './styles'
 Utils        = require './utils'

--- a/lib/package_info.coffee
+++ b/lib/package_info.coffee
@@ -1,6 +1,0 @@
-fs   = require 'fs'
-path = require 'path'
-
-package_json_path = path.resolve(__dirname, '../package.json')
-
-module.exports = PACKAGE_INFO = JSON.parse(fs.readFileSync(package_json_path))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
 
   "engines": {
-    "node": ">= v0.4.12"
+    "node": ">= 0.8"
   },
   "dependencies": {
     "coffee-script": ">= 1.1.3",


### PR DESCRIPTION
I simplified the `PACKAGE_INFO` implementation by removing `lib/package_info` and using `require './package.json'` directly where needed. [Node.js implements this feature](https://github.com/joyent/node/issues/1357) since version 0.8, therefore I raised the node.js version requirement in `package.json` to '>= 0.8'. Really, groc's dependency on node ≥ 0.4.12 is astonishing old (:astonished:) and to my mind node < 0.8 is too insecure for production purposes.

Everything seems to work as expected, see https://gemnasium.com/sjorek/groc .
Are there any objections I'm not aware of ?

Hint: Upcoming features I'm going to offer as pull request(s) depend heavily on this technique.

Cheers & thanks,
Stephan
