### PR TITLE
Feature: clickable folders in table of contents

### DIFF
--- a/lib/styles/default/behavior.coffee
+++ b/lib/styles/default/behavior.coffee
@@ -213,9 +213,15 @@ buildTOCNode = (node, metaInfo) ->
     when 'file'
       #} Single line to avoid extra whitespace
       node$.append """<a class="label" href="#{metaInfo.relativeRoot}#{node.data.targetPath}.html" title="#{node.data.projectPath}"><span class="text">#{node.data.title}</span></a>"""
+      clickLabel = ->
+        selectNode node$
 
     when 'folder'
-      node$.append """<span class="label"><span class="text">#{node.data.title}</span></span>"""
+      node$.append """<a class="label" href="#"><span class="text">#{node.data.title}</span></a>"""
+      clickLabel = (evt) ->
+        selectNode node$
+        node$.toggleClass 'expanded'
+        evt.preventDefault()
 
   if node.children?.length > 0
     children$ = $('<ol class="children"/>')
@@ -224,7 +230,7 @@ buildTOCNode = (node, metaInfo) ->
     node$.append children$
 
   label$ = node$.find('> .label')
-  label$.click -> selectNode node$
+  label$.click clickLabel
 
   discloser$ = $('<span class="discloser"/>').prependTo label$
   discloser$.addClass 'placeholder' unless node.children?.length > 0

--- a/lib/styles/default/behavior.coffee
+++ b/lib/styles/default/behavior.coffee
@@ -209,11 +209,19 @@ buildNav = (metaInfo) ->
 buildTOCNode = (node, metaInfo) ->
   node$ = $("""<li class="#{node.type}"/>""")
 
+  #} just to clarify: we use it in the `clickLabel`-method below, but can
+  #} reference the first time after initializing it a few more lines below
+  discloser = null
+
   switch node.type
     when 'file'
       #} Single line to avoid extra whitespace
       node$.append """<a class="label" href="#{metaInfo.relativeRoot}#{node.data.targetPath}.html" title="#{node.data.projectPath}"><span class="text">#{node.data.title}</span></a>"""
-      clickLabel = ->
+      clickLabel = (evt) ->
+        if evt.target is discloser
+          node$.toggleClass 'expanded'
+          evt.preventDefault()
+          return false
         selectNode node$
 
     when 'folder'
@@ -222,6 +230,7 @@ buildTOCNode = (node, metaInfo) ->
         selectNode node$
         node$.toggleClass 'expanded'
         evt.preventDefault()
+        return false
 
   if node.children?.length > 0
     children$ = $('<ol class="children"/>')
@@ -234,9 +243,7 @@ buildTOCNode = (node, metaInfo) ->
 
   discloser$ = $('<span class="discloser"/>').prependTo label$
   discloser$.addClass 'placeholder' unless node.children?.length > 0
-  discloser$.click (evt) ->
-    node$.toggleClass 'expanded'
-    evt.preventDefault()
+  discloser = discloser$.get(0)
 
   # Persist our references to the node
   fileMap[node.data.targetPath] = node$ if node.type == 'file'


### PR DESCRIPTION
Well, what else should I write ? … it was too annoying, so I implemented clickable folders in the table of contents. Everything works as expected - including keyboard-navigation. (I didn't touch it anyway). I hope I didn't miss anything … well I did not test empty folders as I was not able to reproduce such a combination (empty but visible).

This should also fix: https://github.com/nevir/groc/pull/80 …

So I stay calm and look forward to a successful merge of this pull-request.

Stephan :zzz: 
