### PR TITLE
Add ClojureScript extension to Clojure language in languages.coffee

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -28,7 +28,7 @@ module.exports = LANGUAGES =
     foldPrefix:        '-'
 
   Clojure:
-    nameMatchers:      ['.clj']
+    nameMatchers:      ['.clj', '.cljs']
     pygmentsLexer:     'clojure'
     singleLineComment: [';;']
     ignorePrefix:      '}'


### PR DESCRIPTION
ClojureScript is a compiler for Clojure that shares the same syntax as Clojure, but uses `.cljs` as its file type. I propose the "Clojure" language supports both `.clj` and `.cljs` files as both types can be used inside a single Clojure application.
