### PR TITLE
Fix: remove empty 'doc-section-header'-tags

### DIFF
--- a/lib/styles/default.coffee
+++ b/lib/styles/default.coffee
@@ -137,7 +137,7 @@ module.exports = class Default extends Base
         secondPart.push tag.markdown for tag in sections.metadata if sections.metadata?
         metaOutput += " #{humanize.joinSentence secondPart}"
 
-      output += "<span class='doc-section-header'>#{metaOutput}</span>\n\n" if metaOutput?
+      output += "<span class='doc-section-header'>#{metaOutput}</span>\n\n" if metaOutput isnt ''
 
       output += "#{tag.markdown}\n\n" for tag in sections.description if sections.description?
 


### PR DESCRIPTION
There seems to be a tiny glitch rendering empty …

```
<span class='doc-section-header'></span>
```

… tags, as `metaOutput` is initialized with an empty string `''`, hence it always `exists?`.
