### PR TITLE
Feature: add json-support to languages

### DIFF
--- a/.groc.json
+++ b/.groc.json
@@ -1,5 +1,5 @@
 {
-  "glob": ["lib/**/*.coffee", "README.md", "lib/styles/*/style.sass", "lib/styles/*/*.jade", "scripts/**/*.sh"],
+  "glob": ["lib/**/*.coffee", "README.md", "lib/styles/*/style.sass", "lib/styles/*/*.jade", "scripts/**/*.sh", ".groc.json", "package.json"],
   "github": false,
   "repository-url": "https://github.com/nevir/groc"
 }

--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -94,6 +94,11 @@ module.exports = LANGUAGES =
     ignorePrefix:      '}'
     foldPrefix:        '-'
 
+  JSON                :
+    nameMatchers      : ['.json']
+    pygmentsLexer     : 'json'
+    codeOnly          : true
+
   LaTeX:
     nameMatchers:      ['.tex', '.latex', '.sty']
     pygmentsLexer:     'latex'

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -98,6 +98,9 @@ module.exports = Utils =
     # Special case: If the language is comments-only, we can skip pygments
     return [new @Segment [], lines] if language.commentsOnly
 
+    # Special case: If the language is code-only, we can shorten the process
+    return [new @Segment lines, []] if language.codeOnly
+
     segments = []
     currSegment = new @Segment
 


### PR DESCRIPTION
As upcoming features I'm going to offer as pull requests extensively use JSON files, I thought it might be a good idea to have the possibility of including them in the generated output for documentation purposes. Sadly Douglas Crockford [removed comments from the initial JSON-design](https://plus.google.com/118095276221607585885/posts/RK8qyGVaGSr). Therefore (valid) JSON-files can only be included as plain code.

I decided to implement a new `codeOnly`-flag complementary to the existing `commentOnly`-flag, and use this for JSON-files. As an alternative we could just add `'*.json'` to the existing Javascript entry, but I still have the idea to find a better solution to document JSON-files, therefore I started with this simple and separated addition, without touching the existing Javascript-entry.

Not to forget to mention, that I added the `.groc.json` and `package.json` files to the project-configuration, in order to test and document the implementation.

Hope you like that solution. :cold_sweat: 

Cheers,
Stephan
