### PR TITLE
Feature: multi-line block-comments for coffee-script

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -37,6 +37,19 @@ module.exports = LANGUAGES =
   CoffeeScript:
     nameMatchers:      ['.coffee', 'Cakefile']
     pygmentsLexer:     'coffee-script'
+    multiLineComment  : [
+      # This kind of comment is not yet enabled here, but works, if foldPrefix
+      # has been set to something else than '-'.  Then we can use '-' for
+      # bullet-lists instead of '*' to distinguish bullet-lists from this kind
+      # of block comments.  A patch to switch from '-' to '~' has been prepared
+      # and waits for merging.
+      # } '###*',    ' *',   '###',
+
+      # The block-comment line-matcher `'#'` also works on lines not starting
+      # with `'#'`, because we add unmatched lines to the comments once we are
+      # in a multi-line comment-block and until we left them …
+      '###',     '#',    '###'
+    ]
     singleLineComment: ['#']
     ignorePrefix:      '}'
     foldPrefix:        '-'

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,6 +1,8 @@
-# Miscellaneous code fragments reside here.
-#
-# TODO: These should be migrated into `lib/utils`.
+###
+Miscellaneous code fragments reside here.
+
+TODO: should be migrated into `lib/utils`.
+###
 
 childProcess = require 'child_process'
 path         = require 'path'
@@ -137,6 +139,26 @@ module.exports = Utils =
 
         else if (match = line.match blockLineMatcher)?
           currSegment.comments.push match[2]
+
+        else
+          ###
+          # We are in a multi-line block-comment, hence the whole line is part
+          # of the comment.  This is especially needed for multi-line comment
+          # contents starting immediately at the beginning of a line (without
+          # indention, like those in CoffeeScripts).  The `blockLineMatcher`
+          # from above can not catch those comments due to the `whitespaceMatch`
+          # restrictions from above.  Empty block-comment lines, like the one
+          # after this paragraph have no `whitespaceMatch` restriction …
+          #
+          # @description This comment itself is a multi-line block-comment with
+          #             `@doctags`, indention and (needlessly) prefixed by `'#'`.
+          # @description The very first comment in this file would render it's
+          #              content as code if this `else`-clause is missing.
+          ###
+          if ///^\s*(#{blockLines.join '|'})$///.test line
+            currSegment.comments.push ""
+          else
+            currSegment.comments.push line
 
       # Match that line to the language's multi line comment syntax, if it exists
       else if language.multiLineComment? and (match = line.match blockStartMatcher)?


### PR DESCRIPTION
What should I write ? … I promised support for multi-line block-comments as I missed them very much, and here they are:

```
###
This is supported now.

@description no indention, but with @doctags
###
```

---

```
###
# This is supported too …
#
# @description no indention, but with @doctags and useless #-prefix per line
###
  ###
  @decription … as well as this (indention + @doctags)…
  ###
  ###
  # @decription … or this (indention, @doctags and useless #-prefix per line) …
  ###
```

---

```
###*
 * This is not yet supported due to `foldPrefix` clashes with markdown-comments
 * as described here: https://github.com/nevir/groc/pull/110 . Hence this is currently
 * a simple bulletlist, but actually it's meant to render the following Javascript-comment:
 ###
/**
 * This is not yet supported due to `foldPrefix` clashes with markdown-comments
 * as described …
 */
```

It was not as trivial as I thought, but the final solution works and looks quite simple …
