### PR TITLE
'@' symbol as first character in code block is parsed as a doctag

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -335,7 +335,7 @@ module.exports = Utils =
     pygmentize.stdin.end()
 
   parseDocTags: (segments, project, callback) ->
-    TAG_REGEX = /^\s?@(\w+)(?:\s+(.*))?/
+    TAG_REGEX = /(?:^|\n)@(\w+)(?:\s+(.*))?/
     TAG_VALUE_REGEX = /^(?:"(.*)"|'(.*)'|\{(.*)\}|(.*))$/
 
     try

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -335,7 +335,7 @@ module.exports = Utils =
     pygmentize.stdin.end()
 
   parseDocTags: (segments, project, callback) ->
-    TAG_REGEX = /(?:^|\s)@(\w+)(?:\s+(.*))?/
+    TAG_REGEX = /^\s?@(\w+)(?:\s+(.*))?/
     TAG_VALUE_REGEX = /^(?:"(.*)"|'(.*)'|\{(.*)\}|(.*))$/
 
     try


### PR DESCRIPTION
In languages like ruby and coffee script, it is likely that a code example will start with '@'

By changing the regex to remove the or operator it can be fixed to match only if there is a newline, not 4 spaces signifying a code block

`(?:^|\s)`
should be
`(?:^|\n)`
