### PR TITLE
Fix: missing proper whitespace-handling after foldPrefix- and ignorePrefix 

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -208,6 +208,9 @@ module.exports = Utils =
       stripMarks.push foldPrefix if foldPrefix?
       stripMarks = @regexpEscape(stripMarks).join '|'
 
+      # Strip final space only if one is required, hence yet present.
+      stripSpace = if options.requireWhitespaceAfterToken then '(?:\\s)?' else ''
+
       # A dirty lap-dance performed here …
       singleStrip = ///
         (                           # Capture this group:
@@ -215,6 +218,7 @@ module.exports = Utils =
           #{whitespaceMatch}        #   … plus whitespace
         )
         (?:#{stripMarks})           # The marker(s) to strip from result
+        #{stripSpace}               #   … plus an optional whitespace.
       /// if singleLines?
 
       # … and the corresponding gang-bang here. 8-)
@@ -225,6 +229,7 @@ module.exports = Utils =
           #{whitespaceMatch}        #   … plus whitespace
         )
         (?:#{stripMarks})           # The marker(s) to strip from result
+        #{stripSpace}               #   … plus an optional whitespace.
       /// if blockStarts?
 
     inBlock   = false


### PR DESCRIPTION
This commit strips one whitespace from the comment-line after the `foldPrefix` or the `ignorePrefix` if the whitespace is already required. This strips the unnecessary whitespace from the comments taken from `lib/utils.coffee`, without interfering too much with possible code-block- or bullet-list-indention.

---

Source:

```
        # ^ … if we start this comment with “^” instead of “}” it and all
        # } code up to the next segment's first comment starts folded
```

Current result (notice the _two_ whitespace-chars between `#` and the comment):

```
        #  … if we start this comment with “^” instead of “}” it and all
        #  code up to the next segment's first comment starts folded
```

Patched result (notice the _single_ whitespace between `#` and the comment):

```
        # … if we start this comment with “^” instead of “}” it and all
        # code up to the next segment's first comment starts folded
```

---

Source:

```
        # ^ - fold this list
        # } - fold the list
        # }   - fold the list
```

Current result (notice the _two_ whitespace-chars between `#` and the comment):

```
        #  - fold this list
        #  - fold the list
        #    - fold the list
```

Patched result (notice the _single_ whitespace between `#` and the comment):

```
        # - fold this list
        # - fold the list
        #   - fold the list
```

---

Source:

```
        #^ - fold this list
        #} - fold the list
        #}   - fold the list
```

Current and patched result (notice the single whitespace between `#` and the comment):

```
        # - fold this list
        # - fold the list
        #   - fold the list
```

---

The same principles apply for block-comments too.
