### PR TITLE
Feature: literate language mode and support for literate coffee-script

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -71,7 +71,7 @@ module.exports = LANGUAGES =
     # with `'#'`, because we add unmatched lines to the comments once we are
     # in a multi-line comment-block and until we left them …
     ###
-    multiLineComment  : [
+    multiLineComment:  [
       # Syntax definition for variant 1.
       '###*',   ' *',   ' ###',
       # Syntax definition for variant 2 and 3.
@@ -82,6 +82,38 @@ module.exports = LANGUAGES =
     # first value in the list of 3-tuples above).  If this flag is missing it
     # defaults to `true`. If true it allows one to nest block-comments in
     # different syntax-definitions, like in handlebars or html+php.
+    strictMultiLineEnd:false
+    singleLineComment: ['#']
+    ignorePrefix:      '}'
+    foldPrefix:        '^'
+
+  # This is a clone of the coffee-script definition above plus the `literateCode`
+  # defintion below.
+  #
+  # @see http://ashkenas.com/literate-coffeescript
+  # @see http://coffeescript.org/#literate
+  LiterateCoffeeScript:
+    # The second name-matcher `'.coffee.md'` is untested and might conflict
+    # with the plain markdown-definition above.
+    nameMatchers:      ['.litcoffee', '.coffee.md']
+    pygmentsLexer:     'coffee-script'
+    # Syntax: `[ startMatcher, lineMatcher ]`
+    # - _startMatcher_ :
+    #   A literate coffee-script code-block requires an introducing empty line,
+    #   hence an empty string to distinguish code from nested bullet-lists, as
+    #   described in the `canCode` flag initialization in `lib/utils.coffee`.
+    # - _lineMatcher_ :
+    #   Literate coffee-script is the sum of all code-blocks in a markdown-file.
+    #   This prefix will be stripped from every code-line and the resulting
+    #   code will be processed by `pygments`.
+    literateCode:      [
+      '', '    '
+    ]
+    # Everything below `literateCode` is used to match the code we detected
+    multiLineComment:  [
+      '###*',   ' *',   ' ###',
+      '###' ,   '#' ,   '###'
+    ]
     strictMultiLineEnd:false
     singleLineComment: ['#']
     ignorePrefix:      '}'


### PR DESCRIPTION
… what should I say, here is support for literate coffee-script. If one digs deeper into this mode, you will recognize that code and comments have always separate segments. This is necessary, because large blocks of _literate_ comments will certainly get out of sync with the code they precede. This solution prevents this by not having literate comments side-by-side with code. But of course, _non-literate_ comments in code are processed as usual.

A live-example:
- code: https://github.com/sjorek/groc/blob/master/lib/namespace.litcoffee
- renders to: http://sjorek.github.io/groc/namespace.html

Any feedback, especially to the side-by-side related stuff is always welcome !

Cheers,
Stephan
