### PR TITLE
Added missing include to default to styles.Default

### DIFF
--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -8,6 +8,7 @@ spate = require 'spate'
 CompatibilityHelpers = require './utils/compatibility_helpers'
 Logger               = require './utils/logger'
 Utils                = require './utils'
+styles               = require './styles'
 
 
 # A core concept of `groc` is that your code is grouped into a project, and that there is a certain


### PR DESCRIPTION
If a configured style can't be found, the style will default to 'styles.Default'. However, 'styles' is not defined in 'project.coffee'.
