### PR TITLE
Added support for TypeScript

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -252,6 +252,14 @@ module.exports = LANGUAGES =
     singleLineComment: ['--']
     ignorePrefix:      '}'
     foldPrefix:        '^'
+    
+  TypeScript:
+    nameMatchers:      ['.ts']
+    pygmentsLexer:     'ts'
+    multiLineComment:  ['/*', '*', '*/']
+    singleLineComment: ['//']
+    ignorePrefix:      '}'
+    foldPrefix:        '^'
 
   YAML:
     nameMatchers:      ['.yml', '.yaml']


### PR DESCRIPTION
TypeScript is supported by pygments natively. This adds support for TypeScript to groc, with settings based off of default JS settings.
