### PR TITLE
Adds support for all markdown file extensions

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -2,7 +2,7 @@
 
 module.exports = LANGUAGES =
   Markdown:
-    nameMatchers: ['.md']
+    nameMatchers: ['.md', '.markdown','.mkd', '.mkdn', '.mdown']
     commentsOnly: true
 
   C:


### PR DESCRIPTION
This PR adds support for `.markdown`, `.mkd`, `.mkdn`, and `.mdown` file extensions. I ran into this issue when using Groc with a `.mdown` file, and it led me to [this interesting stackexchange discussion](http://superuser.com/questions/249436/file-extension-for-markdown-files). This is also the official [github supported markdown extension list](https://github.com/github/markup/blob/b865add2e053f8cea3d7f4d9dcba001bdfd78994/lib/github/markups.rb#L1).

Thanks for `groc`! It's awesome.
