### PR TITLE
Add Multi Line Comments to SCSS

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -235,6 +235,7 @@ module.exports = LANGUAGES =
   SCSS:
     nameMatchers:      ['.scss']
     pygmentsLexer:     'scss'
+    multiLineComment:  ['/*', '*', '*/']
     singleLineComment: ['//']
     ignorePrefix:      '}'
     foldPrefix:        '^'


### PR DESCRIPTION
I like commenting my SCSS files. Multi-line style, as defined [in the SCSS reference](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#comments).
