### PR TITLE
Typography: Add Spacing to Headlines and Lists

### DIFF
--- a/lib/styles/default/style.sass
+++ b/lib/styles/default/style.sass
@@ -65,7 +65,7 @@ $inline-code-background-color: #fbf8f3
   font-weight:    100
   letter-spacing: 0.0625em
   line-height:    1.25
-  margin-bottom:  0.5
+  margin-bottom:  0.5em
 
 =tools-font
   +commentary-font
@@ -384,6 +384,7 @@ nav.searching .toc .discloser
 
   ol, ul
     padding-left: 1.75em
+    margin: 1em 0
 
   ol li
     list-style: decimal


### PR DESCRIPTION
I guess the first edit just fixes a typo (`margin-bottom: 0.5`without a unit).

This also adds some margin to lists (in the comment area), otherwise they would collide with other elements that do not have spacings on their own (e.g. a headline following a list in the same comment).
