### PR TITLE
Include example run command from node

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ There are [additional options](http://nevir.github.com/groc/cli.html#cli-options
 groc, if you are interested.
 
 
+### Using groc (from node)
+
+To use groc within node you can use following syntax in your module:
+
+    require('groc').CLI(
+      [
+        "README.md",
+        "TODO.js",
+        "LICENSE.js",
+        "js/*",
+        "-o./webpages/doc"
+      ],
+      function(err) {
+        if (err) console.error(err);
+        else console.log('Done!');
+      }
+    );
+
+Look at the [additional options](http://nevir.github.com/groc/cli.html#cli-options) and include
+the alias in the string, followed by the value (without any blank) as shown above for
+the output directory `-o`.
+
+
 ### Configuring groc (.groc.json)
 
 Groc supports a simple JSON configuration format once you know the config values that appeal to you.


### PR DESCRIPTION
I love the tool, it helps me in a great way to do my stuff!

But I want to run it from node and not the terminal. I have groc in my package.json dependencies which makes it instantly available and runnable for everybody in the project scope.
I had quite a hassle to find the exact syntax on how to do this with certain options.

It was easy when the options were only the files to be used for the documentation, but as soon as I wanted to switch to a different output folder, it got a bit difficult to figure that out.
I also tried it with the .groc.json config file, but that wasn't possible when calling groc.CLI(...).

I still have the feeling I might use the wrong entry point (groc.CLI(...)) for my approach...?
