### PR TITLE
Fix to make flag-type doc tags work

### DIFF
--- a/lib/doc_tags.coffee
+++ b/lib/doc_tags.coffee
@@ -54,23 +54,23 @@ module.exports = DOC_TAGS =
     section:     'type'
 
   accessor:
-    section:     'flag'
+    section:     'flags'
     markdown:    'is an accessor'
   async:
-    section:     'flag'
+    section:     'flags'
     markdown:    'is asynchronous'
   asynchronous:  'async'
   getter:
-    section:     'flag'
+    section:     'flags'
     markdown:    'is a getter'
   recursive:
-    section:     'flag'
+    section:     'flags'
     markdown:    'is recursive'
   refactor:
-    section:     'flag'
+    section:     'flags'
     markdown:    'needs to be refactored'
   setter:
-    section:     'flag'
+    section:     'flags'
     markdown:    'is a setter'
 
   alias:
@@ -199,6 +199,6 @@ module.exports = DOC_TAGS =
   throws:        'throw'
 
   defaultNoValue:
-    section:     'flag'
+    section:     'flags'
   defaultHasValue:
     section:     'metadata'


### PR DESCRIPTION
In the current published version (0.6.1), so called `flag` doc tags don't actually work.

This was due to their definition containing `flag` (singular) but the render method checking for `flags` (plural).

Fixed by changing `flag` to `flags`. Decided pluralized was the right way since this supports multiple flags.

You can confirm the fix by using any `flag` type doc tag (e.g., `@async`).
