### PR TITLE
Recovering segments from pygmetized code fails for some lexers

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -509,7 +509,7 @@ module.exports = Utils =
       result = result.replace('<div class="highlight"><pre>', '').replace('</pre></div>', '')
 
       # Extract our segments from the pygmentized source.
-      highlighted = "\n#{result}\n".split ///.*<span.*#{seg}\s#{div}.*<\/span>.*///
+      highlighted = "\n#{result}\n".split ///.*<span.*#{seg}.*?#{div}.*<\/span>.*///
 
       if highlighted.length != segments.length
         console.log(result)


### PR DESCRIPTION
The regex that splits the segments from the pygmetized code assumes that there will be a single space between SEGMENT and DIVIDER.  This fails for some lexers.  Relaxing this assumption fixes the issue.
