### PR TITLE
Fixed doctype

### DIFF
--- a/lib/styles/default/docPage.jade
+++ b/lib/styles/default/docPage.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(lang="en")
   head
     title= pageTitle


### PR DESCRIPTION
Latest jade expects 'doctype html' instead of '!!! 5'
