### PR TITLE
Fix #156 : Use  relative to root paths for all options in CLI

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -83,7 +83,7 @@ module.exports = CLI = (inputArgs, callback) ->
       describe: "The directory to place generated documentation, relative to the project root."
       alias:    'o'
       default:  './doc'
-      type:     'path'
+      type:     'string'
 
     index:
       describe: "The file to use as the index of the generated documentation."
@@ -198,14 +198,14 @@ module.exports = CLI = (inputArgs, callback) ->
   # exclusions defined by `--except` before we add the result to the project's file list.
   files = {}
   for globExpression in argv.glob
-    files[file] = true for file in glob.sync globExpression
+    files[file] = true for file in glob.sync path.resolve(argv.root, globExpression)
 
   for globExpression in argv.except
-    delete files[file] for file in glob.sync globExpression
+    delete files[file] for file in glob.sync path.resolve(argv.root, globExpression)
 
   # There are several properties that we need to configure on a project before we can go ahead and
   # generate its documentation.
-  project.index = argv.index
+  project.index = path.resolve(argv.root, argv.index)
   project.files = (f for f of files)
   project.stripPrefixes = argv.strip
 


### PR DESCRIPTION
This pull request allow the root directory path to be up in the tree:

``` coffeescript
groc:
  options:
    root:  "../"
    out:  "docs/"
    index:  "README.md"
  all:
    options:
      glob: ["README.md","lib/*.coffee", "css/*.scss"]
```

I edited the files object building of [`cli.coffee`](https://github.com/Plou/groc/blob/ad11ff6d94312b8887cf51a8a2eea69564573259/lib/cli.coffee) to apply the root, so the paths are now consistent with `project.coffee`

I had to edit the out argument type to make it relative to the root directory.
