### PR TITLE
Add Swift support (.swift)

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -277,6 +277,14 @@ module.exports = LANGUAGES =
     ignorePrefix:      '}'
     foldPrefix:        '^'
     
+  Swift:
+    nameMatchers:      ['.swift']
+    pygmentsLexer:     'swift'
+    singleLineComment: ['//']
+    multiLineComment:  ['/*', '*', '*/']
+    ignorePrefix:      '}'
+    foldPrefix:        '^'
+    
   TypeScript:
     nameMatchers:      ['.ts']
     pygmentsLexer:     'ts'


### PR DESCRIPTION
Pygments has support for SwiftLexer but not in released versions right now.
When it does, we will be ready for it.
