### PR TITLE
Updated underscore version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "showdown":      ">= 0.2.0",
     "spate":         ">= 0.1.0",
     "uglify-js":     ">= 1.1.1",
-    "underscore":    ">= 1.2.2"
+    "underscore":    "~1.6.0"
   },
   "devDependencies": {},
 


### PR DESCRIPTION
updated underscore version number to resolve nevir/groc/#167 (breaking
changes in jashkenas/underscore#1805) as suggested by Schoonology
