### PR TITLE
added preserve-extensions functionality

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -118,6 +118,12 @@ module.exports = CLI = (inputArgs, callback) ->
       describe: "A path prefix to strip when generating documentation paths (or --no-strip)."
       alias:    't'
 
+    'preserve-extensions':
+      describe: "Include the file extension in the generated file name."
+      alias: 'x'
+      type: 'boolean'
+      default: false
+
     'empty-lines':
       describe: "Allow empty comment lines."
       default:  true
@@ -231,6 +237,7 @@ module.exports = CLI = (inputArgs, callback) ->
     indexPageTitle: argv['index-page-title']
     onlyRenderNewer: argv['only-render-newer']
     style: style
+    preserveExtensions: argv['preserve-extensions']
 
   # Good to go!
   unless argv.github

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -57,7 +57,7 @@ module.exports = class Project
     # so that they can strip from the remainder.
     @stripPrefixes = [@root + CompatibilityHelpers.pathSep].concat @stripPrefixes
 
-    fileMap   = Utils.mapFiles @root, @files, @stripPrefixes
+    fileMap   = Utils.mapFiles @root, @files, @stripPrefixes, options.preserveExtensions
     indexPath = path.resolve @root, @index
 
     pool = spate.pool (k for k of fileMap), maxConcurrency: @BATCH_SIZE, (currentFile, done) =>

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -69,7 +69,7 @@ module.exports = Utils =
       return pair[1] if baseName.match pair[0]
 
   # Map a list of file paths to relative target paths by stripping prefixes.
-  mapFiles: (resolveRoot, files, stripPrefixes) ->
+  mapFiles: (resolveRoot, files, stripPrefixes, preserveExtensions) ->
     # Ensure that we're dealing with absolute paths across the board.
     files = files.map (f) -> path.resolve resolveRoot, f
 
@@ -93,7 +93,7 @@ module.exports = Utils =
       # We also strip the extension under the assumption that the consumer of
       # this path map is going to substitute in their own.  Plus, if they care
       # about the extension, they can get it from the keys of the map.
-      result[absPath] = if not path.extname(file) then file else file[0...-path.extname(file).length]
+      result[absPath] = if preserveExtensions || not path.extname(file) then file else file[0...-path.extname(file).length]
 
     result
 


### PR DESCRIPTION
This helps in situations where you have two files with the same name, differing only by extension, which happens a lot in C/C++/Objective-C, etc.

e.g. you might have some files like this:
- bar.c
- bar.h
- foo.c
- foo.h
- main.c

which groc generates as:
- bar.html
- bar.html
- foo.html
- foo.html
- main.html

In order to prevent ambiguous filenames, preserve the extension:
- bar.c.html
- bar.h.html
- foo.c.html
- foo.h.html
- main.c.html
