### PR TITLE
Fixed invalid head content.

### DIFF
--- a/lib/styles/default/docPage.jade
+++ b/lib/styles/default/docPage.jade
@@ -2,15 +2,15 @@ doctype html
 html(lang="en")
   head
     title= pageTitle
-  meta(http-equiv="Content-Type", content="text/html; charset=utf-8")
-  meta(name="viewport", content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0")
-  meta(name="groc-relative-root", content=relativeRoot)
-  meta(name="groc-document-path", content=targetPath)
-  meta(name="groc-project-path", content=projectPath)
-  - if (project.githubURL)
-    meta(name="groc-github-url", content=project.githubURL)
-  link(rel="stylesheet", type="text/css", media="all", href=relativeRoot + "assets/style.css")
-  script(type="text/javascript", src=relativeRoot + "assets/behavior.js")
+    meta(http-equiv="Content-Type", content="text/html; charset=utf-8")
+    meta(name="viewport", content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0")
+    meta(name="groc-relative-root", content=relativeRoot)
+    meta(name="groc-document-path", content=targetPath)
+    meta(name="groc-project-path", content=projectPath)
+    - if (project.githubURL)
+      meta(name="groc-github-url", content=project.githubURL)
+    link(rel="stylesheet", type="text/css", media="all", href=relativeRoot + "assets/style.css")
+    script(type="text/javascript", src=relativeRoot + "assets/behavior.js")
 
   body
     #meta


### PR DESCRIPTION
In my generated templates the HTML looked like this:

```
<!DOCTYPE html><html lang="en"><head><title>DataFixtures/README</title></head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"><meta name="groc-relative-root" content="../"><meta name="groc-document-path" content="DataFixtures/README"><meta name="groc-project-path" content="lib/DataFixtures/README.js"><link rel="stylesheet" type="text/css" media="all" href="../assets/style.css"><script type="text/javascript" src="../assets/behavior.js"></script><body>
```

As you can see the `</head>` comes way to early, so i tried to fix this with this PR.
