### PR TITLE
Fix commitMessage option. Use same case as other options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .sass-cache
+.idea
 doc
 node_modules
 npm-debug.log

--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -83,6 +83,7 @@ module.exports = CLI = (inputArgs, callback) ->
       describe: "Commit message when pushing to Github."
       alias:    'm',
       type:     'string'
+      default:  ''
 
     'only-render-newer':
       describe: "Only render files if the source is newer than the output."
@@ -272,8 +273,9 @@ module.exports = CLI = (inputArgs, callback) ->
         project.log.info ''
         project.log.info 'Publishing documentation to github...'
 
-        # The bash publishing script needs a proper or empty string
-        commitMessage = if argv['commit-message'] then '"' + argv['commit-message'] + '"' else ''
+        # The bash publishing script needs a proper string or no argument at all
+        commitMessage = argv['commit-message']
+        commitMessage = '"' + commitMessage + '"' if commitMessage
 
         # Roughly, the publishing script:
         #

--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -79,6 +79,11 @@ module.exports = CLI = (inputArgs, callback) ->
       describe: "Supply your GitHub repository URL (if groc fails to guess it)."
       type:     'string'
 
+    'commit-message':
+      describe: "Commit message when pushing to Github."
+      alias:    'm',
+      type:     'string'
+
     'only-render-newer':
       describe: "Only render files if the source is newer than the output."
       default:  true
@@ -267,13 +272,16 @@ module.exports = CLI = (inputArgs, callback) ->
         project.log.info ''
         project.log.info 'Publishing documentation to github...'
 
+        # The bash publishing script needs a proper or empty string
+        commitMessage = if argv['commit-message'] then '"' + argv['commit-message'] + '"' else ''
+
         # Roughly, the publishing script:
         #
         # 1. Switches to the `gh-pages` branch (creating it if necessary)
         # 2. Copies the generated docs from `.git/groc-tmp` over any existing files in the branch.
         # 3. Creates a commit with _just_ the generated docs; any additional files are removed.
         # 4. Cleans up and switches back to the user's original branch.
-        script = childProcess.spawn path.resolve(__dirname, '..', 'scripts', 'publish-git-pages.sh'), [remote, projectConfig.commitMessage]
+        script = childProcess.spawn path.resolve(__dirname, '..', 'scripts', 'publish-git-pages.sh'), [remote, commitMessage]
 
         script.stdout.on 'data', (data) -> project.log.info  data.toString().trim()
         script.stderr.on 'data', (data) -> project.log.error data.toString().trim()


### PR DESCRIPTION
The recently added commitMessage option breaks if you don't use a `.groc.json` configuration file (projectConfig is empty). For example, command line or using `grunt-groc` and `gulp-groc`.
